### PR TITLE
fix Pod typo

### DIFF
--- a/lib/Catalyst/ActionRole/MethodSignatureDependencyInjection.pm
+++ b/lib/Catalyst/ActionRole/MethodSignatureDependencyInjection.pm
@@ -447,6 +447,7 @@ The current L<Catalyst::Response>
 An arrayref of the current args
 
 =head2 args
+
 =head2 @args
 
 An array of the current args.  Only makes sense if this is the last specified


### PR DESCRIPTION
right now it [renders part of Pod markup](https://metacpan.org/pod/Catalyst::ActionRole::MethodSignatureDependencyInjection#args) on MetaCPAN
